### PR TITLE
feat: クラウド版リリースのお知らせを追加

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app-bar>
+  <v-app-bar extended>
     <v-container class="d-flex align-center">
       <v-app-bar-title>{{ t("header.title") }}</v-app-bar-title>
       <v-spacer></v-spacer>
@@ -35,6 +35,44 @@
       </v-btn>
       <HelpDialog v-model="dialog" />
     </v-container>
+
+    <template #extension>
+      <ClientOnly>
+        <div
+          v-if="showAnnouncement"
+          class="announcement-link"
+          role="link"
+          tabindex="0"
+          :aria-label="t('announcement.aria')"
+          @click="openCloud"
+          @keydown.enter.prevent="openCloud"
+          @keydown.space.prevent="openCloud"
+        >
+          <v-alert
+            class="announcement-alert rounded-0 ma-0"
+            density="compact"
+            variant="flat"
+            color="primary"
+            icon="mdi-information-outline"
+          >
+            <template #append>
+              <v-btn
+                icon="mdi-close"
+                variant="text"
+                size="small"
+                class="announcement-close"
+                :aria-label="t('announcement.close')"
+                @click.stop="dismissAnnouncement"
+              />
+            </template>
+
+            <span class="announcement-text">{{
+              t("announcement.cloudRelease")
+            }}</span>
+          </v-alert>
+        </div>
+      </ClientOnly>
+    </template>
   </v-app-bar>
 
   <!-- ドロアーメニュー -->
@@ -106,6 +144,18 @@ import HelpDialog from "./HelpDialog.vue";
 const dialog = ref(false);
 const { t, locale, locales } = useI18n();
 
+const cloudUrl = "https://www.tcg-shadowbox.app/";
+
+const showAnnouncement = ref(true);
+
+const openCloud = () => {
+  window.location.href = cloudUrl;
+};
+
+const dismissAnnouncement = () => {
+  showAnnouncement.value = false;
+};
+
 // アプリメニューの機能をインポート
 const {
   isMenuOpen,
@@ -139,5 +189,28 @@ const switchLanguage = (code: LocaleCode) => {
 
 .v-app-bar {
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.announcement-link {
+  display: block;
+  width: 100%;
+  cursor: pointer;
+}
+
+.announcement-alert {
+  background-color: rgb(var(--v-theme-primary)) !important;
+  color: rgb(var(--v-theme-on-primary)) !important;
+}
+
+.announcement-alert :deep(.v-icon) {
+  color: inherit;
+}
+
+.announcement-text {
+  white-space: pre-line;
+}
+
+.announcement-close {
+  color: inherit;
 }
 </style>

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -119,5 +119,10 @@
   },
   "prompts": {
     "enterFileName": "Enter the file name for export:"
+  },
+  "announcement": {
+    "cloudRelease": "The cloud version of TCG Shadowbox Planner has been released.\nhttps://www.tcg-shadowbox.app/",
+    "aria": "Open the cloud version website",
+    "close": "Dismiss announcement"
   }
 }

--- a/app/i18n/locales/ja.json
+++ b/app/i18n/locales/ja.json
@@ -113,6 +113,11 @@
   "prompts": {
     "enterFileName": "エクスポートするファイル名を入力してください："
   },
+  "announcement": {
+    "cloudRelease": "TCG Shadowbox Planner のクラウド版がリリースされました。こちらからご利用いただけます。\nhttps://www.tcg-shadowbox.app/",
+    "aria": "クラウド版サイトを開く",
+    "close": "お知らせを閉じる"
+  },
   "menu": {
     "title": "メニュー",
     "saveData": "データの保存",


### PR DESCRIPTION
This pull request adds a new announcement banner to the app header, notifying users about the release of the cloud version of TCG Shadowbox Planner. The banner is accessible, dismissible, and fully localized in both English and Japanese. The main changes are grouped into UI enhancements, accessibility/localization, and supporting logic.

**UI Enhancements:**

* Added an announcement banner to the header using the `v-app-bar`'s `extension` slot, which informs users about the new cloud version and provides a clickable link to the website. The banner can be dismissed by the user. (`app/components/AppHeader.vue` [[1]](diffhunk://#diff-0ecff9b7f0a79b79210c118a5437418d5d9e25351ea57b5229c4933baac7d73aL2-R2) [[2]](diffhunk://#diff-0ecff9b7f0a79b79210c118a5437418d5d9e25351ea57b5229c4933baac7d73aR38-R75)
* Added styles for the announcement banner, ensuring it matches the app's design and is visually distinct. (`app/components/AppHeader.vue` [app/components/AppHeader.vueR193-R215](diffhunk://#diff-0ecff9b7f0a79b79210c118a5437418d5d9e25351ea57b5229c4933baac7d73aR193-R215))

**Accessibility and Localization:**

* Localized the announcement text, ARIA label, and close button in both English and Japanese locale files, ensuring the banner is accessible and understandable for all users. (`app/i18n/locales/en.json` [[1]](diffhunk://#diff-a7bc0b57fc655519da2ac2de8aa1b765769c80bb1a417a88e1d361cd0784e57dR122-R126) `app/i18n/locales/ja.json` [[2]](diffhunk://#diff-771b56095a1a0f5a2ec4e5294846fda0be6ff1a5c4814b8251d43bcec51b2a27R116-R120)

**Supporting Logic:**

* Implemented logic to handle showing, opening (navigating to the cloud site), and dismissing the announcement banner in the header component. (`app/components/AppHeader.vue` [app/components/AppHeader.vueR147-R158](diffhunk://#diff-0ecff9b7f0a79b79210c118a5437418d5d9e25351ea57b5229c4933baac7d73aR147-R158))